### PR TITLE
Binding DateTime issue with Xamarin

### DIFF
--- a/Naxam.Stripe.iOS/ApiDefinition.cs
+++ b/Naxam.Stripe.iOS/ApiDefinition.cs
@@ -2701,7 +2701,7 @@ namespace StripeSdk
         // */
         // @property (nonatomic, nullable, readonly) NSDate *canceledAt;
         [Export("canceledAt")]
-        DateTime CanceledAt { get; }
+        NSDate CanceledAt { get; }
 
         // /**
         // Capture method of this PaymentIntent
@@ -2722,7 +2722,7 @@ namespace StripeSdk
         // */
         // @property (nonatomic, nullable, readonly) NSDate *created;
         [Export("created")]
-        DateTime created { get; }
+        NSDate created { get; }
 
         // /**
         // The currency associated with the PaymentIntent.


### PR DESCRIPTION
Fixed an issue in Xamarin project that would bring up a "The registrar found an invalid type System.DateTime in signature for method ops. Use Foundation.NSDate instead." Error when building the project with the and trying to use the binding's ShareClient().